### PR TITLE
disables Kubernetes from trying reset permissions

### DIFF
--- a/cifs
+++ b/cifs
@@ -59,7 +59,7 @@ init() {
 	assertBinaryInstalled jq jq
 	assertBinaryInstalled mountpoint util-linux
 	assertBinaryInstalled base64 coreutils
-	echo '{ "status": "Success", "message": "The fstab/cifs flexvolume plugin was initialized successfully", "capabilities": { "attach": false } }'
+	echo '{ "status": "Success", "message": "The fstab/cifs flexvolume plugin was initialized successfully", "capabilities": { "attach": false, "fsGroup": false } }'
 	exit 0
 }
 


### PR DESCRIPTION
Kubernetes will try to change the permissions on all of the files inside a CIFS share if fsGroup is specified. This can causes failures in mounting when lots of files are present. It can also cause issues according to some reports.

https://github.com/kubernetes/kubernetes/issues/93802

fixes #16